### PR TITLE
Switch to webpack 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ES3ify loader for webpack.
 ----
 
 ## Install
-
+For webpack 1.x use version 0.x. For webpack 2.x and 3.x use version 1.x.
 ```bash
 $ npm i es3ify-loader --save
 ```

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var transform = require('es3ify').transform;
 
 module.exports = function(code) {
-  this.cacheable();
   return transform(code);
 };

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "es3ify-loader",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "ES3ify loader for webpack.",
   "repository": {
     "type": "git",
     "url": "https://github.com/sorrycc/es3ify-loader"
+  },
+  "peerDependencies": {
+     "webpack": "2 || 3"
   },
   "homepage": "https://github.com/sorrycc/es3ify-loader",
   "author": "chencheng <sorrycc@gmail.com>",


### PR DESCRIPTION
I want to use this plugin for webpack 2 but there's no cacheable() method in webpack2 and loaders are cacheable by default. 

Bumped version, removed that call and added webpack 2 requirement